### PR TITLE
Allow containers to mark some paths as needing special configuration for websockets

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -128,6 +128,8 @@ upstream {{ $upstream_name }} {
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
 
+{{ $websocket_paths := groupByMulti $containers "Env.WEBSOCKET_PATHS" "," }}
+
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
 
@@ -201,6 +203,16 @@ server {
                 include /etc/nginx/vhost.d/default_location;
                 {{ end }}
 	}
+{{ range $path, $ignored := $websocket_paths }}
+        # websocket path: {{$path}}
+        location {{trim $path}} {
+                proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}{{trim $path}};
+                proxy_connect_timeout 10m;
+                proxy_read_timeout 7d;
+                proxy_send_timeout 7d;
+        }
+{{end}}
+
 }
 
 {{ end }}
@@ -235,6 +247,17 @@ server {
                 include /etc/nginx/vhost.d/default_location;
                 {{ end }}
 	}
+
+{{ range $path, $ignored := $websocket_paths }}
+        # websocket path: {{$path}}
+        location {{trim $path}} {
+                proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}{{trim $path}};
+                proxy_read_timeout 7d;
+                proxy_connect_timeout 10m;
+                proxy_send_timeout 7d;
+        }
+{{end}}
+
 }
 
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}


### PR DESCRIPTION
Adds to the template a lookup of `WEBSOCKET_PATHS` in the environment of a container, and adds `location` entries to the NginX configuration for that host, for each path so specified, which set the `proxy_read_timeout`, `proxy_send_timeout` to avoid NginX dropping the connection every minute, and increases the `proxy_connect_timeout`.